### PR TITLE
ODP-4280: Enhance Flink HS Web UI with obfuscated SSL password suppor…

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -35,7 +35,6 @@ under the License.
 	<properties>
 		<fs.azure.sdk.version>1.16.0</fs.azure.sdk.version>
 		<fs.jackson.core.version>2.9.4</fs.jackson.core.version>
-		<jetty.version>9.3.24.v20180605</jetty.version>
 	</properties>
 
 	<dependencies>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -318,6 +318,14 @@ under the License.
 			<artifactId>powermock-api-mockito2</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>${jetty.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -35,6 +35,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslProvider;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 
+import org.eclipse.jetty.util.security.Password;
+
 import javax.annotation.Nullable;
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
@@ -287,7 +289,7 @@ public class SSLUtils {
 
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         try (InputStream keyStoreFile = Files.newInputStream(new File(keystoreFilePath).toPath())) {
-            keyStore.load(keyStoreFile, keystorePassword.toCharArray());
+            keyStore.load(keyStoreFile, SSLUtils.decryptPassword(keystorePassword).toCharArray());
         }
 
         final KeyManagerFactory kmf;
@@ -296,9 +298,16 @@ public class SSLUtils {
         } else {
             kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         }
-        kmf.init(keyStore, certPassword.toCharArray());
+        kmf.init(keyStore, SSLUtils.decryptPassword(certPassword).toCharArray());
 
         return kmf;
+    }
+
+    private static String decryptPassword(String certPassword) {
+        if (certPassword.startsWith("OBF:")) {
+            return new Password(certPassword).toString();
+        }
+        return certPassword;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@ under the License.
 		<minikdc.version>3.2.4</minikdc.version>
 		<hive.version>2.3.9</hive.version>
 		<orc.version>1.5.6</orc.version>
+		<jetty.version>9.4.56.v20240826</jetty.version>
 		<japicmp.referenceVersion>1.19.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.27.1</spotless.version>


### PR DESCRIPTION
…t (#5)

* ODP-4280: flink ssl rest passwords support OBF

* ODP-4280: flink ssl rest passwords support OBF-v1

* ODP-4280: adding jetty version as configurable

* ODP-4280: allowing unique jetty version in flink
