### PR TITLE
ODP-6293 : Upgrade Scala from 2.12.7 to 2.12.18 to fix classfile parsing issue with updated commons-lang3 dependency

### DIFF
--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -10,8 +10,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.google.flatbuffers:flatbuffers-java:1.12.0
-- io.netty:netty-buffer:4.1.100.Final
-- io.netty:netty-common:4.1.100.Final
+- io.netty:netty-buffer:4.1.132.Final
+- io.netty:netty-common:4.1.132.Final
 - joda-time:joda-time:2.5
 - org.apache.arrow:arrow-format:13.0.0
 - org.apache.arrow:arrow-memory-core:13.0.0

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -36,6 +36,7 @@ under the License.
 			chill ArraysAsListSerializer
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
 		</surefire.module.config>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -36,6 +36,7 @@ under the License.
 			chill ArraysAsListSerializer
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
 		</surefire.module.config>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@ under the License.
 		<scala.macros.version>2.1.1</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.18</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
@@ -993,7 +993,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.18</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
@@ -1153,7 +1153,7 @@ under the License.
 
 			<properties>
 				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
-				<scala.version>2.12.15</scala.version>
+				<scala.version>2.12.18</scala.version>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
 			</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -919,7 +919,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.1.100.Final</version>
+				<version>4.1.132.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
This patch has been tested locally.