### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -919,7 +919,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.1.100.Final</version>
+				<version>4.1.132.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
This patch was tested locally.