### PR TITLE
ODP-6302 : Bump Scala to 2.12.18 and skip japicmp for scala modules

### DIFF
--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -36,6 +36,7 @@ under the License.
 			chill ArraysAsListSerializer
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
 		</surefire.module.config>
+                <japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -36,6 +36,7 @@ under the License.
 			chill ArraysAsListSerializer
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
 		</surefire.module.config>
+                <japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@ under the License.
 		<scala.macros.version>2.1.1</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.18</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
@@ -1004,7 +1004,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.18</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
@@ -1164,7 +1164,7 @@ under the License.
 
 			<properties>
 				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
-				<scala.version>2.12.15</scala.version>
+				<scala.version>2.12.18</scala.version>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
 			</properties>
 


### PR DESCRIPTION
The patch has been tested locally !