### PR TITLE
OSV-18068 - CVE - Increasing log4j2 version to 2.25.4 to fix the flink/lib log4j CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ under the License.
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->


### PR DESCRIPTION
- Library : log4j-core, log4j-1.2-api
- Version : -> 2.25.4
- Tickets : OSV-18068, OSV-18067, OSV-18066, OSV-18065, OSV-18064, OSV-18063