### PR TITLE
ODP-6966: Bump stale hive.version deps to 3.2.3.7-2 release line

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -1304,7 +1304,7 @@ under the License.
 		<profile>
 			<id>hive3</id>
 			<properties>
-				<hive.version>4.0.0.3.2.3.6-3000</hive.version>
+				<hive.version>4.0.0.3.2.3.7-2</hive.version>
 				<derby.version>10.14.1.0</derby.version>
 			</properties>
 

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -35,6 +35,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
+		<odp.release.version>3.2.3.7-2</odp.release.version>
 		<hiverunner.version>4.0.0</hiverunner.version>
 		<reflections.version>0.9.8</reflections.version>
 		<derby.version>10.10.2.0</derby.version>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -1304,7 +1304,7 @@ under the License.
 		<profile>
 			<id>hive3</id>
 			<properties>
-				<hive.version>4.0.0.3.2.3.7-2</hive.version>
+				<hive.version>4.0.0.${odp.release.version}</hive.version>
 				<derby.version>10.14.1.0</derby.version>
 			</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@ under the License.
 	</modules>
 
 	<properties>
+		<odp.release.version>3.2.3.7-2</odp.release.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<flink.hadoop.version>2.10.2</flink.hadoop.version>
@@ -197,7 +198,7 @@ under the License.
 			to revisit the impact at that time.
 		-->
 		<minikdc.version>3.2.4</minikdc.version>
-		<hive.version>4.0.1.3.2.3.7-2</hive.version>
+		<hive.version>4.0.1.${odp.release.version}</hive.version>
 		<orc.version>1.5.6</orc.version>
 		<jetty.version>9.4.56.v20240826</jetty.version>
 		<japicmp.referenceVersion>1.19.0</japicmp.referenceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@ under the License.
 			to revisit the impact at that time.
 		-->
 		<minikdc.version>3.2.4</minikdc.version>
-		<hive.version>4.0.1.3.2.3.6-3000</hive.version>
+		<hive.version>4.0.1.3.2.3.7-2</hive.version>
 		<orc.version>1.5.6</orc.version>
 		<jetty.version>9.4.56.v20240826</jetty.version>
 		<japicmp.referenceVersion>1.19.0</japicmp.referenceVersion>


### PR DESCRIPTION
Align flink's two hardcoded hive dependency versions from the stale 3.2.3.6-3000 suffix to the current 3.2.3.7-2 release line.

