### PR TITLE
OSV-21623 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@ under the License.
 		<curator.version>5.4.0</curator.version>
 		<avro.version>1.11.3</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
-		<jackson-bom.version>2.15.3</jackson-bom.version>
+		<jackson-bom.version>2.18.6</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-21623